### PR TITLE
Phase 0100: MCP Server & AI Agent Skills

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -3,6 +3,10 @@
     "lvl": {
       "command": "/Users/ppatterson/.local/bin/lvl",
       "args": ["mcp"]
+    },
+    "to-markdown": {
+      "command": "uv",
+      "args": ["--directory", ".", "run", "--extra", "mcp", "python", "-m", "to_markdown.mcp"]
     }
   }
 }

--- a/.specflow/orchestration-state.json
+++ b/.specflow/orchestration-state.json
@@ -5,7 +5,7 @@
     "name": "to-markdown",
     "path": "/Users/ppatterson/dev/to-markdown"
   },
-  "last_updated": "2026-02-26T15:17:05.537Z",
+  "last_updated": "2026-02-26T16:03:35.347Z",
   "orchestration": {
     "phase": {
       "id": null,
@@ -14,17 +14,21 @@
       "branch": null,
       "status": "not_started",
       "goals": [
-        "Directory conversion with recursive support",
-        "Glob pattern support",
-        "Progress reporting",
-        "Error handling with continue-on-error",
-        "All tests passing"
+        "Build MCP server with convert_file, convert_batch, list_formats, get_status tools",
+        "Create mcp.json config for Claude Code/Desktop integration",
+        "Create Claude Code skill definition for /convert",
+        "Document agent setup for Codex and Gemini",
+        "Ensure agent-friendly structured output from MCP tools",
+        "Tests for all MCP tool handlers"
       ],
-      "hasUserGate": false,
+      "hasUserGate": true,
       "userGateStatus": "confirmed",
-      "userGateCriteria": "Directory conversion with mixed formats; progress reporting; all tests pass"
+      "userGateCriteria": "**USER GATE**: Claude Code can invoke to-markdown via MCP tools end-to-end"
     },
-    "next_phase": null,
+    "next_phase": {
+      "number": "0110",
+      "name": "Background Processing"
+    },
     "step": {
       "current": "design",
       "index": 0,
@@ -105,6 +109,15 @@
         "phase_name": "Batch Processing",
         "branch": "0050-batch-processing",
         "completed_at": "2026-02-26T15:17:05.536Z",
+        "tasks_completed": 0,
+        "tasks_total": 0
+      },
+      {
+        "type": "phase_completed",
+        "phase_number": "0100",
+        "phase_name": "MCP Server & AI Agent Skills",
+        "branch": "0100-mcp-server-ai-agent-skills",
+        "completed_at": "2026-02-26T16:03:35.347Z",
         "tasks_completed": 0,
         "tasks_total": 0
       }

--- a/.specify/archive/0100-mcp-skills/discovery.md
+++ b/.specify/archive/0100-mcp-skills/discovery.md
@@ -1,0 +1,112 @@
+# Discovery: Phase 0100 - MCP Server & AI Agent Skills
+
+## Date: 2026-02-26
+
+## Codebase Examination
+
+### Current Architecture
+
+to-markdown is a CLI file-to-Markdown converter wrapping Kreuzberg (Rust-based, 76+ formats).
+The codebase has clean module boundaries:
+
+- **cli.py**: Typer CLI entry point with all flags
+- **core/pipeline.py**: `convert_file()` - the main conversion function
+- **core/batch.py**: `convert_batch()`, `discover_files()`, `resolve_glob()`
+- **core/extraction.py**: Kreuzberg adapter (`extract_file()`, `ExtractionResult`)
+- **core/frontmatter.py**: YAML frontmatter composition
+- **core/constants.py**: All constants (single source of truth)
+- **smart/**: LLM features (clean, summary, images via Gemini)
+
+### Key Interfaces for MCP Wrapping
+
+**convert_file** (pipeline.py):
+```python
+def convert_file(
+    input_path: Path,
+    output_path: Path | None = None,
+    *,
+    force: bool = False,
+    clean: bool = False,
+    summary: bool = False,
+    images: bool = False,
+) -> Path  # Returns output file path
+```
+
+**convert_batch** (batch.py):
+```python
+def convert_batch(
+    files: list[Path],
+    output_dir: Path | None = None,
+    *,
+    batch_root: Path | None = None,
+    force: bool = False,
+    clean: bool = False,
+    summary: bool = False,
+    images: bool = False,
+    fail_fast: bool = False,
+    quiet: bool = False,
+) -> BatchResult
+```
+
+**BatchResult** (batch.py):
+```python
+@dataclass
+class BatchResult:
+    succeeded: list[Path]
+    failed: list[tuple[Path, str]]
+    skipped: list[tuple[Path, str]]
+    exit_code: int  # property
+```
+
+### Exceptions to Handle
+- `FileNotFoundError`: Input file doesn't exist
+- `UnsupportedFormatError(ExtractionError)`: Format not supported
+- `OutputExistsError`: Output exists without --force
+- `ExtractionError`: Base extraction error
+
+### Constraints Discovered
+
+1. **convert_file writes to disk**: Returns a Path, not content. MCP tools need to either
+   read the output file back, or we need a separate code path that returns content directly.
+2. **stdout corruption risk**: Rich progress bars and Typer echo write to stdout. MCP stdio
+   transport uses stdout for JSON-RPC. Must ensure no stdout leakage.
+3. **LLM features are optional**: `google-genai` is in `[llm]` extras. MCP server needs
+   graceful handling when LLM deps aren't installed.
+4. **Large output**: Claude Code has a ~25K token limit for MCP tool output. Large documents
+   could exceed this. Need truncation strategy.
+
+## Research Summary
+
+### MCP Python SDK
+
+- **Package**: `mcp` on PyPI (v1.26.0, by Anthropic)
+- **API**: `FastMCP` from `mcp.server.fastmcp` - decorator-based tool definitions
+- **Transport**: stdio (universal across all agents)
+- **Error handling**: `ToolError` from `mcp.server.fastmcp.exceptions`
+- **Python 3.14**: Not officially listed in classifiers but likely works (pure Python SDK)
+
+### Agent Configuration
+
+| Agent | Config Format | Config Location |
+|-------|--------------|-----------------|
+| Claude Code | JSON | `.mcp.json` (project) or `~/.claude.json` (user) |
+| Claude Desktop | JSON | `~/Library/Application Support/Claude/claude_desktop_config.json` |
+| OpenAI Codex | TOML | `.codex/config.toml` or `~/.codex/config.toml` |
+| Google Gemini CLI | JSON | `~/.gemini/settings.json` |
+
+All use stdio transport with identical `command` + `args` pattern.
+
+### Key Design Decisions
+
+- **D-63**: Use official `mcp` package (not standalone `fastmcp`) for stability
+- **D-64**: stdio transport only (universal, no persistent server needed)
+- **D-65**: Pin `mcp>=1.26,<2` to avoid v2 breaking changes
+- **D-66**: MCP tools return markdown content directly (not file paths) for single files;
+  return structured summaries for batch operations
+- **D-67**: Always `force=True` internally for MCP single-file conversion (no interactive
+  overwrite prompts in MCP context)
+- **D-68**: Create `convert_to_string()` helper in pipeline.py that returns content instead
+  of writing to disk, to avoid unnecessary I/O for MCP use case
+- **D-69**: MCP server lives at `src/to_markdown/mcp/server.py` as a subpackage (consistent
+  with smart/ pattern), runnable via `python -m to_markdown.mcp`
+- **D-70**: Add `[mcp]` optional extra in pyproject.toml for the mcp dependency

--- a/.specify/archive/0100-mcp-skills/plan.md
+++ b/.specify/archive/0100-mcp-skills/plan.md
@@ -1,0 +1,114 @@
+# Plan: Phase 0100 - MCP Server & AI Agent Skills
+
+## Architecture
+
+### New Module: `src/to_markdown/mcp/`
+
+```
+src/to_markdown/
+  mcp/
+    __init__.py        # Package marker with __main__ support
+    __main__.py        # Entry point: python -m to_markdown.mcp
+    server.py          # FastMCP server with tool definitions
+    tools.py           # Tool handler implementations (business logic)
+```
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `src/to_markdown/core/pipeline.py` | Add `convert_to_string()` function |
+| `src/to_markdown/core/constants.py` | Add MCP-related constants |
+| `pyproject.toml` | Add `[mcp]` optional extra, add `to-markdown-mcp` script |
+| `.mcp.json` | New file - Claude Code MCP config |
+| `README.md` | Add AI Agent Integration section |
+
+### New Test Files
+
+| File | Purpose |
+|------|---------|
+| `tests/test_mcp_tools.py` | Unit tests for MCP tool handlers |
+| `tests/test_mcp_server.py` | Server initialization and tool registration |
+| `tests/test_convert_to_string.py` | Pipeline string output tests |
+
+## Technical Decisions
+
+### D-63: Official mcp package over standalone fastmcp
+The official `mcp` package (by Anthropic, v1.26.0) includes FastMCP and is the reference
+implementation. Standalone `fastmcp` v3.0 has extra features but adds a separate dependency.
+Official package is more stable and better documented for our agents.
+
+### D-64: stdio transport only
+All four target agents (Claude Code, Claude Desktop, Codex CLI, Gemini CLI) support stdio.
+It requires no persistent server process - the agent spawns the server on demand.
+
+### D-65: Pin mcp>=1.26,<2
+The mcp package v2 is in pre-alpha. Pinning to v1.x avoids breaking changes.
+
+### D-66: Return content directly for single files
+MCP `convert_file` returns markdown content as a string (not a file path). This is more
+useful for agents who want to reason about the content. For large files, truncate with
+a pointer to the full output file.
+
+### D-67: Always force=True for MCP single-file conversion
+MCP tools can't prompt for interactive confirmation. For `convert_file`, we skip file
+writing entirely (use `convert_to_string`). For `convert_batch`, we use `force=True`
+since the agent explicitly requested conversion.
+
+### D-68: convert_to_string() in pipeline.py
+New function that does extract -> frontmatter -> [smart features] -> assemble, returning
+the string. Shares 95% of logic with `convert_file()` via a shared `_build_content()`
+internal function.
+
+### D-69: mcp/ subpackage (not single file)
+Follows the same pattern as `smart/` - subpackage with clear module boundaries.
+Separates server setup (server.py) from tool logic (tools.py).
+
+### D-70: [mcp] optional extra
+The `mcp` dependency is only needed if running the MCP server. Core CLI and smart
+features work without it. Pattern matches `[llm]` extras.
+
+## Implementation Order
+
+1. **Constants & pipeline changes** (foundation)
+   - Add MCP constants to constants.py
+   - Add `convert_to_string()` to pipeline.py
+   - Tests for convert_to_string
+
+2. **MCP server & tools** (core feature)
+   - Create mcp/ subpackage
+   - Implement tool handlers in tools.py
+   - Set up FastMCP server in server.py
+   - __main__.py entry point
+
+3. **Configuration & documentation** (integration)
+   - .mcp.json for Claude Code
+   - pyproject.toml updates
+   - README agent integration section
+
+4. **Tests** (verification)
+   - Tool handler unit tests
+   - Server registration tests
+   - Error path tests
+
+## Risks
+
+1. **Python 3.14 + mcp SDK**: The mcp package lists support for 3.10-3.13. May need
+   workaround if 3.14 causes issues. Mitigation: test early, file issue if needed.
+
+2. **stdout leakage**: Rich progress bars default to stderr but should be verified.
+   Kreuzberg's internal logging needs checking. Mitigation: redirect stdout in server
+   startup if needed.
+
+3. **Large output truncation**: Need to balance between returning useful content and
+   staying within agent token limits. Mitigation: configurable MAX_MCP_OUTPUT_CHARS
+   constant with sensible default.
+
+## Constitution Compliance
+
+- **Principle I (Completeness)**: MCP tools expose all conversion options available in CLI
+- **Principle II (Magic Defaults)**: Tools work with zero optional params; smart features opt-in
+- **Principle III (Kreuzberg Wrapper)**: MCP wraps the same pipeline, no new extraction logic
+- **Principle IV (Simplicity)**: Thin MCP layer over existing pipeline functions
+- **Principle V (Testing)**: All tool handlers have unit tests
+- **Principle VI (No Sloppiness)**: Constants in constants.py, no duplication

--- a/.specify/archive/0100-mcp-skills/spec.md
+++ b/.specify/archive/0100-mcp-skills/spec.md
@@ -1,0 +1,97 @@
+# Specification: Phase 0100 - MCP Server & AI Agent Skills
+
+## Overview
+
+Add an MCP (Model Context Protocol) server so that Claude Code, Codex, Gemini CLI, and
+other AI agents can invoke to-markdown's file conversion programmatically via standardized
+tool calls over stdio transport.
+
+## Requirements
+
+### R1: MCP Server Module
+The project must provide an MCP server as a Python subpackage at `src/to_markdown/mcp/`
+that can be run via `python -m to_markdown.mcp` or `uv run python -m to_markdown.mcp`.
+
+### R2: convert_file Tool
+The MCP server must expose a `convert_file` tool that accepts a file path and optional
+flags (force, clean, summary, images), converts the file to markdown, and returns the
+markdown content directly as a string response.
+
+### R3: convert_batch Tool
+The MCP server must expose a `convert_batch` tool that accepts a directory path or glob
+pattern and optional flags, converts matching files, and returns a structured summary
+(succeeded count, failed files with errors, skipped files with reasons).
+
+### R4: list_formats Tool
+The MCP server must expose a `list_formats` tool that returns a description of supported
+file formats (based on Kreuzberg's capabilities).
+
+### R5: get_status Tool
+The MCP server must expose a `get_status` tool that returns the tool version, whether
+LLM features are available (google-genai installed + API key configured), and basic
+system information.
+
+### R6: Pipeline String Output
+A new function `convert_to_string()` must be added to `core/pipeline.py` that performs
+the same conversion as `convert_file()` but returns the markdown content as a string
+instead of writing to disk. This avoids unnecessary file I/O for the MCP use case.
+
+### R7: Error Handling
+All MCP tools must translate to-markdown exceptions into `ToolError` responses with
+clear, actionable error messages. Unhandled exceptions must not leak stack traces.
+
+### R8: Claude Code Configuration
+The project must include a `.mcp.json` file at the project root for Claude Code
+project-scope MCP server discovery.
+
+### R9: Agent Configuration Documentation
+The README must include an "AI Agent Integration" section documenting MCP server setup
+for Claude Code, Claude Desktop, OpenAI Codex CLI, and Google Gemini CLI.
+
+### R10: Output Size Safety
+For single-file conversions, if the output exceeds a configurable token limit
+(MAX_MCP_OUTPUT_CHARS constant), the tool must write the full output to a file and return
+a truncated preview with the output file path.
+
+### R11: No stdout Leakage
+The MCP server must ensure no library (Rich, Typer, Kreuzberg) writes to stdout, which
+would corrupt the stdio JSON-RPC transport. Logging must go to stderr. The server entry
+point must suppress stdout from any imported library.
+
+### R14: Structured Response Envelope
+MCP tool responses must include structured metadata alongside content:
+- `convert_file`: Response includes source path, detected format, word/char count,
+  warnings (if any), and then the markdown content
+- `convert_batch`: Response includes per-file results (succeeded with paths, failed
+  with error messages, skipped with reasons), plus aggregate counts
+- `list_formats`: Structured list of format categories and extensions
+- `get_status`: Structured key-value pairs for version, LLM availability, etc.
+
+### R12: Optional Dependency
+The `mcp` package must be an optional dependency under a `[mcp]` extra in pyproject.toml,
+so core CLI functionality is unaffected.
+
+### R13: Tests
+All MCP tool handlers must have unit tests with mocked pipeline calls. Tests must cover
+success paths, error paths (missing file, unsupported format, missing API key), and
+output size truncation.
+
+## Out of Scope
+
+- HTTP/SSE transport (stdio only for this phase)
+- Background/async task processing (Phase 0110)
+- MCP resources or prompts (tools only)
+- Claude Code skill definitions (MCP tools provide equivalent agent access)
+- Publishing to MCP registries
+
+## Acceptance Criteria
+
+1. `uv run python -m to_markdown.mcp` starts the MCP server on stdio
+2. Claude Code can discover and call `convert_file` via `.mcp.json`
+3. `convert_file` returns markdown content for a valid file
+4. `convert_batch` returns structured results for a directory
+5. `list_formats` returns supported format information
+6. `get_status` returns version and LLM availability
+7. Errors return `ToolError` with clear messages
+8. All tests pass (`uv run pytest`)
+9. Lint clean (`uv run ruff check`)

--- a/.specify/archive/0100-mcp-skills/tasks.md
+++ b/.specify/archive/0100-mcp-skills/tasks.md
@@ -1,0 +1,196 @@
+# Tasks: Phase 0100 - MCP Server & AI Agent Skills
+
+## Section 1: Pipeline Foundation
+
+### T001: Add MCP constants to constants.py
+- **Files**: `src/to_markdown/core/constants.py`
+- **Action**: Add constants:
+  - `MAX_MCP_OUTPUT_CHARS = 80_000` (~20K tokens, safe for agent limits)
+  - `MCP_SERVER_NAME = "to-markdown"`
+  - `MCP_SERVER_INSTRUCTIONS` (string describing the server for agent discovery)
+  - `SUPPORTED_FORMATS_DESCRIPTION` (static string listing Kreuzberg's supported formats
+    derived from Kreuzberg docs - no runtime API exists for querying formats)
+- **Test**: Verify constants importable
+- **Blocked by**: None
+
+### T002: Add convert_to_string() to pipeline.py
+- **Files**: `src/to_markdown/core/pipeline.py`
+- **Action**: Refactor `convert_file()` to extract shared logic into `_build_content()`
+  internal function. `_build_content` signature:
+  ```python
+  def _build_content(
+      input_path: Path,
+      *,
+      clean: bool = False,
+      summary: bool = False,
+      images: bool = False,
+  ) -> str:
+  ```
+  This does: extract -> frontmatter -> [clean] -> [images] -> [summary] -> assemble string.
+  `convert_file()` calls `_build_content()` then writes to disk.
+  Add public `convert_to_string()` that calls `_build_content()` and returns the string:
+  ```python
+  def convert_to_string(
+      input_path: Path,
+      *,
+      clean: bool = False,
+      summary: bool = False,
+      images: bool = False,
+  ) -> str:
+  ```
+  `convert_to_string` validates input exists and is a file, then delegates to `_build_content`.
+  No output path, no force flag, no file writing.
+- **Test**: `tests/test_pipeline.py` - add tests for convert_to_string
+- **Blocked by**: None
+
+### T003: Test convert_to_string
+- **Files**: `tests/test_pipeline.py`
+- **Action**: Add tests:
+  - Returns string with frontmatter + content
+  - Works with clean/summary/images flags (mocked)
+  - Raises FileNotFoundError for missing input
+  - Raises UnsupportedFormatError for bad formats
+  - Does NOT write any file to disk
+- **Blocked by**: T002
+
+## Section 2: MCP Server Core
+
+### T004: Create mcp/ subpackage structure
+- **Files**: `src/to_markdown/mcp/__init__.py`, `src/to_markdown/mcp/__main__.py`
+- **Action**: Create package:
+  - `__init__.py`: Re-export `run_server` from `server.py` for console script entry point
+  - `__main__.py`: Entry point for `python -m to_markdown.mcp`. Imports and calls
+    `run_server()`. Configures logging to stderr. Suppresses stdout from imported libraries
+    by redirecting sys.stdout to os.devnull during server startup if needed.
+- **Blocked by**: None
+
+### T005: Implement MCP tool handlers (tools.py)
+- **Files**: `src/to_markdown/mcp/tools.py`
+- **Action**: Implement four tool handler functions (pure business logic, no MCP
+  decorators). All return structured text responses (R14) not just raw content:
+  - `handle_convert_file(file_path, clean, summary, images) -> str`:
+    Calls `convert_to_string()`. Returns structured response with source path, detected
+    format, char count, any warnings, then markdown content. Truncates content at
+    MAX_MCP_OUTPUT_CHARS with note about output file path if exceeded.
+  - `handle_convert_batch(directory_path, recursive, clean, summary, images) -> str`:
+    Calls `discover_files(Path(directory_path), recursive=recursive)` then
+    `convert_batch(files, ...)`. The `recursive` param maps to `discover_files()`'s
+    existing `recursive` kwarg (default True). Returns structured summary with per-file
+    results.
+  - `handle_list_formats() -> str`: Returns `SUPPORTED_FORMATS_DESCRIPTION` constant
+    (static, derived from Kreuzberg docs since no runtime query API exists).
+  - `handle_get_status() -> str`: Returns version (via `to_markdown.__version__`),
+    LLM availability (check google-genai importable + GEMINI_API_KEY set), Python version.
+  Each function validates inputs and raises ValueError with descriptive messages for
+  invalid inputs (ToolError wrapping happens in server.py).
+- **Blocked by**: T001, T002
+
+### T006: Implement FastMCP server (server.py)
+- **Files**: `src/to_markdown/mcp/server.py`
+- **Action**: Create FastMCP server with:
+  - `mcp = FastMCP(MCP_SERVER_NAME, instructions=MCP_SERVER_INSTRUCTIONS)`
+  - Four `@mcp.tool()` decorated functions that delegate to tools.py handlers
+  - Annotated parameters with `Field(description=...)` for clear agent-visible docs
+  - ToolError wrapping: catch ValueError/exceptions from handlers, raise ToolError
+  - `def run_server()` function called from __main__.py, runs `mcp.run(transport="stdio")`
+  - Logging configured to stderr (not stdout - critical for stdio transport)
+  - Ensure Rich progress bars are suppressed when called via MCP (pass `quiet=True`
+    to convert_batch, verify convert_to_string doesn't trigger Rich output)
+  - `mask_error_details=True` to prevent stack trace leakage
+- **Blocked by**: T004, T005
+
+## Section 3: Configuration & Integration
+
+### T007: Add [mcp] optional extra to pyproject.toml
+- **Files**: `pyproject.toml`
+- **Action**: Add `[mcp]` optional dependency group with `mcp>=1.26,<2`. Add
+  `to-markdown-mcp` console script entry point pointing to
+  `to_markdown.mcp.server:run_server`.
+- **Blocked by**: None
+
+### T008: Create .mcp.json for Claude Code
+- **Files**: `.mcp.json`
+- **Action**: Create project-scope MCP config (committed to version control for automatic
+  discovery by Claude Code users who clone the repo):
+  ```json
+  {
+    "mcpServers": {
+      "to-markdown": {
+        "command": "uv",
+        "args": ["--directory", ".", "run", "--extra", "mcp", "python", "-m", "to_markdown.mcp"]
+      }
+    }
+  }
+  ```
+- **Blocked by**: T006
+
+### T009: Update README with AI Agent Integration section
+- **Files**: `README.md`
+- **Action**: Add section after "Development" covering:
+  - What MCP is (one sentence)
+  - Claude Code setup (auto via .mcp.json, or manual `claude mcp add`)
+  - Claude Desktop setup (config file path + JSON)
+  - OpenAI Codex CLI setup (config.toml)
+  - Google Gemini CLI setup (settings.json)
+  - Available tools with brief descriptions
+  - Example: how an agent would use convert_file
+- **Blocked by**: T008
+
+## Section 4: Tests
+
+### T010: Test MCP tool handlers
+- **Files**: `tests/test_mcp_tools.py`
+- **Action**: Unit tests for tools.py handlers with mocked pipeline:
+  - `handle_convert_file`: success with structured response, file not found, unsupported
+    format, output truncation when content exceeds MAX_MCP_OUTPUT_CHARS
+  - `handle_convert_batch`: success with mixed results, empty directory, structured
+    per-file results
+  - `handle_list_formats`: returns expected format info string
+  - `handle_get_status`: returns version and LLM availability
+  - Invalid parameter types produce clear ValueError messages
+- **Blocked by**: T005
+
+### T011: Test MCP server registration and stdout safety
+- **Files**: `tests/test_mcp_server.py`
+- **Action**: Tests for server.py:
+  - Server creates successfully
+  - All four tools are registered with correct names
+  - Tool parameter schemas match expected types (correct required/optional params)
+  - ToolError is raised for handler exceptions (not raw exceptions)
+  - Verify no stdout output during tool execution (capture stdout, assert empty)
+  - Server module can be imported; graceful ImportError if mcp package missing
+- **Blocked by**: T006
+
+### T012: Lint, format, and smoke test
+- **Files**: All modified files
+- **Action**: Run `uv run ruff check`, `uv run ruff format --check`, `uv run pytest`.
+  Fix any issues. Verify `uv run python -m to_markdown.mcp` starts without error
+  (quick manual check).
+- **Blocked by**: T010, T011
+
+## Section 5: Documentation Sync
+
+### T013: Update coding-standards.md with mcp/ directory
+- **Files**: `.specify/memory/coding-standards.md`
+- **Action**: Add `mcp/` directory to project structure section with file descriptions.
+- **Blocked by**: T006
+
+### T014: Update tech-stack.md with mcp dependency
+- **Files**: `.specify/memory/tech-stack.md`
+- **Action**: Add mcp package to tech stack table. Update distribution section to
+  note MCP server availability. Record decisions D-63 through D-70.
+- **Blocked by**: T007
+
+### T015: Record decisions in decisions.md
+- **Files**: `.specify/discovery/decisions.md`
+- **Action**: Record decisions D-63 through D-70 from the plan.
+- **Blocked by**: T006
+
+### T016: Write testing instructions
+- **Files**: `README.md` (How to Test section)
+- **Action**: Add "How to Test (Phase 0100: MCP Server)" section with:
+  - How to install MCP extra: `uv sync --extra mcp`
+  - How to start the MCP server manually: `uv run python -m to_markdown.mcp`
+  - How to test from Claude Code (add server, call tool)
+  - Expected output for each tool
+- **Blocked by**: T012

--- a/.specify/history/HISTORY.md
+++ b/.specify/history/HISTORY.md
@@ -4,6 +4,61 @@ This file contains summaries of completed phases, archived by `specflow phase cl
 
 ---
 
+## 0100 - MCP Server & AI Agent Skills
+
+**Completed**: 2026-02-26
+
+# Phase 0100: MCP Server & AI Agent Skills
+
+**Goal**: Build an MCP (Model Context Protocol) server and skill definitions so that
+Claude Code, Codex, Gemini, and other AI agents can invoke to-markdown programmatically
+without shell scripting.
+
+**Scope**:
+
+### 1. MCP Server
+- Implement an MCP server (`src/to_markdown/mcp/server.py`) using the MCP Python SDK
+- Expose tools: `convert_file`, `convert_batch`, `list_formats`, `get_status`
+- `convert_file` tool: accepts file path + options (force, clean, summary, images),
+  returns converted markdown content or output path
+- `convert_batch` tool: accepts directory/glob + options, returns batch result summary
+- `list_formats` tool: returns supported formats (from Kreuzberg)
+- `get_status` tool: returns version, available features (LLM configured or not)
+- Proper error responses with structured error codes
+- stdio transport (standard for local MCP servers)
+
+### 2. MCP Configuration Files
+- Generate `mcp.json` for Claude Code / Claude Desktop integration
+- Document configuration for Codex and Gemini agent setups
+- Include both "local development" and "installed" server configurations
+
+### 3. Agent-Friendly Output
+- MCP tool responses include structured metadata envelope (source path, format, stats)
+  alongside the markdown content - not just raw markdown
+- Large content returns are truncated with a pointer to the full output file
+- Batch results include per-file success/failure/skip details
+
+### 5. Tests
+- Test MCP server tool handlers with mock inputs
+- Test tool schema validation (correct parameters, types)
+- Test error handling (missing file, unsupported format, missing API key)
+- Stdout suppression verified (no library writes to stdout in MCP mode)
+
+**Deliverables**:
+- [ ] MCP server with convert_file, convert_batch, list_formats, get_status tools
+- [ ] stdio transport working for local usage
+- [ ] mcp.json configuration for Claude Code / Claude Desktop
+- [ ] Agent setup documentation for Codex and Gemini
+- [ ] Tests for all MCP tool handlers
+- [ ] README updated with MCP/agent integration section
+
+**Verification Gate**: **USER GATE** - Claude Code can invoke to-markdown via MCP
+tools. `convert_file` and `convert_batch` tools work from an AI agent session.
+
+**Estimated Complexity**: Medium-High
+
+---
+
 ## 0050 - Batch Processing
 
 **Completed**: 2026-02-26

--- a/.specify/memory/coding-standards.md
+++ b/.specify/memory/coding-standards.md
@@ -32,6 +32,11 @@ to-markdown/
         clean.py           # --clean flag: LLM artifact repair
         summary.py         # --summary flag: Gemini document summarization
         images.py          # --images flag: Gemini vision image description
+      mcp/                 # MCP server for AI agent integration (optional)
+        __init__.py
+        __main__.py        # Entry point: python -m to_markdown.mcp
+        server.py          # FastMCP server with tool definitions
+        tools.py           # Tool handler implementations
   tests/
     test_batch.py          # Batch processing tests
     fixtures/              # Test input files per format

--- a/.specify/memory/tech-stack.md
+++ b/.specify/memory/tech-stack.md
@@ -40,6 +40,16 @@ Default model: `gemini-2.5-flash` (GA, free tier). Override via `GEMINI_MODEL` e
 |-----------|---------|---------|----------|
 | rich | 13.0+ | Terminal progress bars for batch processing | D-55, D-61 |
 
+## MCP Server
+
+| Technology | Version | Purpose | Decision |
+|-----------|---------|---------|----------|
+| mcp | 1.26+ (<2) | MCP Python SDK for AI agent integration | D-63, D-65 |
+| FastMCP | (in mcp) | Decorator-based tool definitions | D-63 |
+
+MCP server exposes to-markdown as tools for Claude Code, Claude Desktop, Codex CLI, and
+Gemini CLI. Uses stdio transport (D-64). Optional dependency via `[mcp]` extras (D-70).
+
 ## Infrastructure
 
 | Technology | Purpose | Decision |
@@ -53,6 +63,7 @@ Default model: `gemini-2.5-flash` (GA, free tier). Override via `GEMINI_MODEL` e
 | Method | Status | Notes |
 |--------|--------|-------|
 | Local (uv run) | Current | D-21: local only for now |
+| MCP server | Current | AI agents via `python -m to_markdown.mcp` (D-64, D-69) |
 | PyPI | Future | May publish eventually (D-26) |
 | pipx / uv tool | Future | For global CLI install |
 

--- a/.specify/phases/0110-background-processing.md
+++ b/.specify/phases/0110-background-processing.md
@@ -1,0 +1,68 @@
+---
+phase: 0110
+name: background-processing
+status: not_started
+created: 2026-02-26
+updated: 2026-02-26
+---
+
+# Phase 0110: Background Processing
+
+**Goal**: Add asynchronous background processing so that long-running conversions
+(especially batch + smart features) don't block the caller. Expose via both CLI flags
+and MCP tools.
+
+**Scope**:
+
+### 1. Task Manager
+- `src/to_markdown/core/tasks.py`: Task lifecycle management
+- Task dataclass: id (UUID), status (pending/running/completed/failed), input,
+  output_path, created_at, completed_at, error, result_summary
+- SQLite-backed task store (lightweight, zero-config, file-based)
+- Task store location: `~/.to-markdown/tasks.db` (configurable via env var)
+- Automatic cleanup of completed tasks older than configurable retention period
+
+### 2. CLI Background Flag
+- `--background` / `--bg` flag: kicks off conversion in background, returns task ID
+- Output: `Task started: abc123. Check status with: to-markdown --status abc123`
+- `--status <task-id>`: show task status (pending/running/completed/failed + details)
+- `--status all`: list all recent tasks with status summary
+- `--cancel <task-id>`: cancel a running task
+- Background execution via subprocess (fork and detach from terminal)
+
+### 3. MCP Background Tools
+- `start_conversion` tool: starts background task, returns task ID immediately
+- `get_task_status` tool: check task status by ID
+- `list_tasks` tool: list all tasks with status
+- `cancel_task` tool: cancel a running task
+- Enables AI agents to fire-and-forget long conversions and poll for results
+
+### 4. Process Management
+- Background worker process with proper signal handling
+- PID file management to prevent orphan processes
+- Graceful shutdown on SIGTERM/SIGINT
+- Stdout/stderr redirected to log file per task
+
+### 5. Tests
+- Test task creation, status transitions, completion
+- Test SQLite store CRUD operations
+- Test CLI --background flag output format
+- Test --status and --cancel commands
+- Test MCP background tool handlers
+- Test task cleanup / retention
+
+**Deliverables**:
+- [ ] Task manager with SQLite store
+- [ ] --background flag for CLI (returns task ID)
+- [ ] --status and --cancel CLI commands
+- [ ] MCP tools: start_conversion, get_task_status, list_tasks, cancel_task
+- [ ] Background process management (fork, PID, signals)
+- [ ] Task retention / cleanup
+- [ ] Tests for all task lifecycle scenarios
+- [ ] README updated with background processing section
+
+**Verification Gate**: **USER GATE** - `to-markdown docs/ --background` returns a task
+ID immediately. `to-markdown --status <id>` shows progress. MCP `start_conversion`
+tool works from an AI agent session.
+
+**Estimated Complexity**: High

--- a/.specify/phases/0120-easy-install.md
+++ b/.specify/phases/0120-easy-install.md
@@ -1,0 +1,75 @@
+---
+phase: 0120
+name: easy-install
+status: not_started
+created: 2026-02-26
+updated: 2026-02-26
+---
+
+# Phase 0120: Easy Install for Non-Technical Users
+
+**Goal**: Create a one-command install experience for non-technical users on both macOS
+and Windows. Clone the repo, run one script, and everything works.
+
+**Scope**:
+
+### 1. macOS Install Script
+- `install.sh`: Single bash script that handles everything
+- Detects and installs uv (if missing) via official installer
+- Detects and installs Python 3.14+ via uv
+- Detects and installs Tesseract via Homebrew (for OCR support)
+- Runs `uv sync --all-extras` to install all dependencies
+- Creates a shell alias or symlink so `to-markdown` works globally
+- Validates the installation by running `to-markdown --version`
+- Colorful, friendly output with progress indicators
+- Handles errors gracefully with clear remediation steps
+
+### 2. Windows Install Script
+- `install.ps1`: PowerShell script for Windows
+- Detects and installs uv (if missing) via official installer
+- Detects and installs Python 3.14+ via uv
+- Detects and installs Tesseract via winget or choco (for OCR support)
+- Runs `uv sync --all-extras`
+- Adds to-markdown to PATH or creates a batch wrapper
+- Validates the installation
+- Clear output with progress indicators
+
+### 3. Configuration Wizard
+- Interactive first-run setup (triggered on first use or via `to-markdown --setup`)
+- Prompts for GEMINI_API_KEY (optional, with explanation of what it enables)
+- Creates .env file in project directory
+- Tests API key if provided
+- Explains core vs smart features
+
+### 4. Quick Start Guide
+- `INSTALL.md`: Step-by-step guide with screenshots/terminal output examples
+- macOS section and Windows section
+- Troubleshooting FAQ (common errors and fixes)
+- "What to do next" section with example commands
+- Written for non-technical audience (no assumed knowledge of terminals)
+
+### 5. Uninstall
+- `uninstall.sh` / `uninstall.ps1`: Clean removal scripts
+- Removes symlinks/aliases, virtual environment, and config files
+- Preserves any converted .md files
+
+### 6. Tests
+- Test install script logic (dependency detection, error handling) via unit tests
+- Test configuration wizard flow with mocked inputs
+- Test that --setup flag triggers wizard
+- Manual testing checklist for both platforms
+
+**Deliverables**:
+- [ ] install.sh for macOS (one-command install)
+- [ ] install.ps1 for Windows (one-command install)
+- [ ] Configuration wizard (--setup flag)
+- [ ] INSTALL.md with step-by-step guide for both platforms
+- [ ] uninstall.sh / uninstall.ps1
+- [ ] Tests for install logic and config wizard
+- [ ] README updated to reference INSTALL.md for non-technical users
+
+**Verification Gate**: **USER GATE** - Fresh macOS machine: clone repo, run
+`./install.sh`, run `to-markdown test.pdf`. Fresh Windows machine: clone repo, run
+`./install.ps1`, run `to-markdown test.pdf`. Both work without manual intervention.
+
+**Estimated Complexity**: Medium

--- a/.specify/phases/0130-production-readiness.md
+++ b/.specify/phases/0130-production-readiness.md
@@ -1,0 +1,82 @@
+---
+phase: 0130
+name: production-readiness
+status: not_started
+created: 2026-02-26
+updated: 2026-02-26
+---
+
+# Phase 0130: Production Readiness & Documentation
+
+**Goal**: Clean up all documentation, finalize governance artifacts, and prepare the
+project for production deployment and public release.
+
+**Scope**:
+
+### 1. README Overhaul
+- Rewrite README.md as a polished, public-facing document
+- Add badges (Python version, license, tests passing)
+- Feature highlights with examples
+- Clear install instructions (link to INSTALL.md for detailed guide)
+- Usage examples covering all major workflows
+- Architecture overview (brief, with diagram if helpful)
+- Contributing section
+- License section
+
+### 2. Documentation Cleanup
+- Audit and update all memory documents (constitution, coding-standards,
+  testing-strategy, tech-stack, glossary)
+- Remove stale references to old phases or outdated decisions
+- Ensure all decision records (D-1 through D-62+) are accurate
+- Archive or remove any orphaned spec/plan files
+- Verify ROADMAP.md reflects actual project state
+
+### 3. Code Cleanup
+- Audit all source files for TODO/FIXME/HACK comments — resolve or document
+- Ensure all public functions have docstrings
+- Run full lint + format pass, fix any warnings
+- Verify no dead code or unused imports
+- Confirm all constants are in constants.py (no strays)
+- Verify no files exceed 300-line limit
+
+### 4. Test Suite Hardening
+- Run full test suite, fix any flaky tests
+- Verify coverage meets acceptable threshold
+- Add any missing edge case tests identified during audit
+- Ensure all test fixtures are programmatically generated (no binary blobs in repo)
+- Update testing-strategy.md with final test count and coverage
+
+### 5. CI/CD Setup
+- GitHub Actions workflow for CI (lint, test, format check on PR)
+- Python version matrix (3.14+)
+- Optional: publish to PyPI workflow (manual trigger)
+- Badge generation for README
+
+### 6. Release Preparation
+- Set version to 1.0.0 in pyproject.toml
+- Write CHANGELOG.md summarizing all phases
+- Tag v1.0.0 release
+- Create GitHub release with notes
+- Update tech-stack.md distribution section
+
+### 7. Governance Finalization
+- Update constitution version if needed
+- Close out any open decisions
+- Final memory document reconciliation
+- Mark all phases complete in ROADMAP.md
+
+**Deliverables**:
+- [ ] README.md rewritten for public audience
+- [ ] All memory documents audited and current
+- [ ] Code audit complete (no TODOs, dead code, or lint warnings)
+- [ ] Test suite passing with documented coverage
+- [ ] GitHub Actions CI workflow
+- [ ] CHANGELOG.md
+- [ ] Version 1.0.0 tagged and released
+- [ ] All governance docs finalized
+
+**Verification Gate**: **USER GATE** - README is polished and accurate. CI passes.
+`uv run pytest` and `uv run ruff check` both clean. Version 1.0.0 tagged. User
+approves project is ready for public/production use.
+
+**Estimated Complexity**: Medium (breadth over depth, mostly documentation and cleanup)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,8 @@ uv run ruff format --check      # format check
 ## Architecture
 
 Kreuzberg wrapper pipeline: extract -> compose frontmatter -> assemble -> write output.
-Core modules in `src/to_markdown/core/`. See coding-standards.md for details.
+Core modules in `src/to_markdown/core/`. MCP server in `src/to_markdown/mcp/`.
+See coding-standards.md for details.
 
 ## Commit Style
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -47,6 +47,10 @@ This allows inserting urgent work without renumbering existing phases.
 | 0030 | Format Quality & Testing | ✅ Complete | **USER GATE**: Golden file tests pass for PDF, DOCX, PPTX, XLSX, HTML, images |
 | 0040 | Smart Features | ✅ Complete | **USER GATE**: `--summary` and `--images` flags work correctly with Gemini |
 | 0050 | Batch Processing | ✅ Complete | Directory conversion with mixed formats; progress reporting; all tests pass |
+| 0100 | MCP Server & AI Agent Skills | ✅ Complete | **USER GATE**: Claude Code can invoke to-markdown via MCP tools end-to-end |
+| 0110 | Background Processing | ⬜ Not Started | **USER GATE**: `--background` flag works; MCP `start_conversion` tool works from agent session |
+| 0120 | Easy Install | ⬜ Not Started | **USER GATE**: Fresh macOS/Windows machine: clone, run install script, `to-markdown` works |
+| 0130 | Production Readiness & Docs | ⬜ Not Started | **USER GATE**: README polished, CI passes, v1.0.0 tagged, user approves for release |
 
 **Legend**: ⬜ Not Started | 🔄 In Progress | ✅ Complete | **USER GATE** = Requires user verification
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,9 @@ llm = [
   "tenacity>=8.0",
   "python-dotenv>=1.0",
 ]
+mcp = [
+  "mcp>=1.26,<2",
+]
 dev = [
   "ruff>=0.15.2",
   "pytest>=9.0",
@@ -32,6 +35,7 @@ dev = [
 
 [project.scripts]
 to-markdown = "to_markdown.cli:app"
+to-markdown-mcp = "to_markdown.mcp.server:run_server"
 
 [build-system]
 requires = ["hatchling"]

--- a/src/to_markdown/core/constants.py
+++ b/src/to_markdown/core/constants.py
@@ -40,6 +40,32 @@ IMAGE_DESCRIPTION_TEMPERATURE = 0.2
 SUMMARY_SECTION_HEADING = "## Summary"
 IMAGE_SECTION_HEADING = "## Image Descriptions"
 
+# --- MCP Server ---
+MCP_SERVER_NAME = "to-markdown"
+MCP_SERVER_INSTRUCTIONS = (
+    "File-to-Markdown converter optimized for LLM consumption. "
+    "Converts PDF, DOCX, XLSX, PPTX, HTML, images, and 70+ other formats "
+    "to clean Markdown with YAML frontmatter metadata. "
+    "Powered by Kreuzberg (Rust-based extraction). "
+    "Optional LLM features (--clean, --summary, --images) require GEMINI_API_KEY."
+)
+MAX_MCP_OUTPUT_CHARS = 80_000
+
+SUPPORTED_FORMATS_DESCRIPTION = """\
+to-markdown supports 76+ file formats via Kreuzberg (Rust-based extraction engine).
+
+**Document formats**: PDF, DOCX, DOC, ODT, RTF, EPUB, MOBI
+**Spreadsheets**: XLSX, XLS, ODS, CSV, TSV
+**Presentations**: PPTX, PPT, ODP
+**Web**: HTML, XHTML, XML, MHTML
+**Images (OCR)**: PNG, JPEG, TIFF, BMP, GIF, WebP (requires Tesseract)
+**Plain text**: TXT, MD, RST, ORG, TEX, LOG
+**Code**: Most programming language source files
+**Other**: EML, MSG (email), JSON, YAML, TOML
+
+Note: OCR-based formats (images, scanned PDFs) require Tesseract to be installed.\
+"""
+
 # --- LLM Prompts ---
 CLEAN_PROMPT = """\
 You are a document formatting repair tool. Your ONLY job is to fix extraction \

--- a/src/to_markdown/mcp/__init__.py
+++ b/src/to_markdown/mcp/__init__.py
@@ -1,0 +1,5 @@
+"""MCP server for to-markdown file conversion tools."""
+
+from to_markdown.mcp.server import run_server
+
+__all__ = ["run_server"]

--- a/src/to_markdown/mcp/__main__.py
+++ b/src/to_markdown/mcp/__main__.py
@@ -1,0 +1,21 @@
+"""Entry point for `python -m to_markdown.mcp`."""
+
+import logging
+import sys
+
+
+def main() -> None:
+    """Configure logging and start the MCP server."""
+    # Configure logging to stderr (critical for stdio transport - stdout is JSON-RPC)
+    logging.basicConfig(
+        level=logging.INFO,
+        stream=sys.stderr,
+        format="%(levelname)s: %(message)s",
+    )
+
+    from to_markdown.mcp.server import run_server
+
+    run_server()
+
+
+main()

--- a/src/to_markdown/mcp/server.py
+++ b/src/to_markdown/mcp/server.py
@@ -1,0 +1,107 @@
+"""FastMCP server exposing to-markdown file conversion tools."""
+
+import logging
+from typing import Annotated
+
+from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.exceptions import ToolError
+from pydantic import Field
+
+from to_markdown.core.constants import MCP_SERVER_INSTRUCTIONS, MCP_SERVER_NAME
+from to_markdown.mcp.tools import (
+    handle_convert_batch,
+    handle_convert_file,
+    handle_get_status,
+    handle_list_formats,
+)
+
+logger = logging.getLogger(__name__)
+
+mcp = FastMCP(MCP_SERVER_NAME, instructions=MCP_SERVER_INSTRUCTIONS)
+
+
+@mcp.tool()
+def convert_file(
+    file_path: Annotated[str, Field(description="Absolute path to the file to convert")],
+    clean: Annotated[
+        bool, Field(description="Fix extraction artifacts via LLM (requires GEMINI_API_KEY)")
+    ] = False,
+    summary: Annotated[
+        bool, Field(description="Generate document summary via LLM (requires GEMINI_API_KEY)")
+    ] = False,
+    images: Annotated[
+        bool, Field(description="Describe images via LLM vision (requires GEMINI_API_KEY)")
+    ] = False,
+) -> str:
+    """Convert a single file to LLM-optimized Markdown with YAML frontmatter.
+
+    Extracts text from documents (PDF, DOCX, XLSX, PPTX, HTML, images, and more)
+    and produces clean Markdown with metadata frontmatter. Returns the markdown
+    content directly.
+    """
+    try:
+        return handle_convert_file(file_path, clean=clean, summary=summary, images=images)
+    except ValueError as exc:
+        raise ToolError(str(exc)) from exc
+    except Exception as exc:
+        logger.exception("convert_file failed")
+        raise ToolError(f"Conversion failed: {exc}") from exc
+
+
+@mcp.tool()
+def convert_batch(
+    directory_path: Annotated[str, Field(description="Absolute path to the directory to convert")],
+    recursive: Annotated[bool, Field(description="Scan subdirectories recursively")] = True,
+    clean: Annotated[
+        bool, Field(description="Fix extraction artifacts via LLM (requires GEMINI_API_KEY)")
+    ] = False,
+    summary: Annotated[
+        bool, Field(description="Generate document summary via LLM (requires GEMINI_API_KEY)")
+    ] = False,
+    images: Annotated[
+        bool, Field(description="Describe images via LLM vision (requires GEMINI_API_KEY)")
+    ] = False,
+) -> str:
+    """Convert all supported files in a directory to Markdown.
+
+    Recursively discovers and converts files, skipping hidden files and unsupported
+    formats. Returns a structured summary with per-file results.
+    """
+    try:
+        return handle_convert_batch(
+            directory_path,
+            recursive=recursive,
+            clean=clean,
+            summary=summary,
+            images=images,
+        )
+    except ValueError as exc:
+        raise ToolError(str(exc)) from exc
+    except Exception as exc:
+        logger.exception("convert_batch failed")
+        raise ToolError(f"Batch conversion failed: {exc}") from exc
+
+
+@mcp.tool()
+def list_formats() -> str:
+    """List all file formats supported by to-markdown.
+
+    Returns a categorized list of supported formats including documents,
+    spreadsheets, presentations, images, and more.
+    """
+    return handle_list_formats()
+
+
+@mcp.tool()
+def get_status() -> str:
+    """Get to-markdown version and feature availability.
+
+    Returns version info, Python version, and whether LLM-powered smart features
+    (clean, summary, images) are available.
+    """
+    return handle_get_status()
+
+
+def run_server() -> None:
+    """Start the MCP server on stdio transport."""
+    mcp.run(transport="stdio")

--- a/src/to_markdown/mcp/tools.py
+++ b/src/to_markdown/mcp/tools.py
@@ -1,0 +1,188 @@
+"""MCP tool handler implementations (pure business logic, no MCP decorators)."""
+
+import logging
+import os
+import sys
+from pathlib import Path
+
+from to_markdown import __version__
+from to_markdown.core.constants import (
+    GEMINI_API_KEY_ENV,
+    MAX_MCP_OUTPUT_CHARS,
+    SUPPORTED_FORMATS_DESCRIPTION,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def handle_convert_file(
+    file_path: str,
+    *,
+    clean: bool = False,
+    summary: bool = False,
+    images: bool = False,
+) -> str:
+    """Convert a single file and return structured response with markdown content."""
+    path = Path(file_path)
+    if not path.exists():
+        msg = f"File not found: {file_path}"
+        raise ValueError(msg)
+    if not path.is_file():
+        msg = f"Not a file: {file_path}"
+        raise ValueError(msg)
+
+    _validate_llm_flags(clean=clean, summary=summary, images=images)
+
+    from to_markdown.core.pipeline import convert_to_string
+
+    content = convert_to_string(path, clean=clean, summary=summary, images=images)
+
+    # Build structured response envelope
+    char_count = len(content)
+    lines = [
+        f"**Source**: {path.name}",
+        f"**Format**: {path.suffix.lstrip('.') or 'unknown'}",
+        f"**Characters**: {char_count:,}",
+    ]
+
+    features = [f for f in ["clean", "summary", "images"] if locals()[f]]
+    if features:
+        lines.append(f"**Features**: {', '.join(features)}")
+
+    # Truncate if content exceeds limit
+    if char_count > MAX_MCP_OUTPUT_CHARS:
+        truncated = content[:MAX_MCP_OUTPUT_CHARS]
+        lines.append(
+            f"\n**Note**: Output truncated ({char_count:,} chars exceeds "
+            f"{MAX_MCP_OUTPUT_CHARS:,} limit). Full content available at: "
+            f"{path.with_suffix('.md')}"
+        )
+        lines.append(f"\n---\n\n{truncated}\n\n[... truncated ...]")
+    else:
+        lines.append(f"\n---\n\n{content}")
+
+    return "\n".join(lines)
+
+
+def handle_convert_batch(
+    directory_path: str,
+    *,
+    recursive: bool = True,
+    clean: bool = False,
+    summary: bool = False,
+    images: bool = False,
+) -> str:
+    """Convert all files in a directory and return structured results."""
+    path = Path(directory_path)
+    if not path.exists():
+        msg = f"Directory not found: {directory_path}"
+        raise ValueError(msg)
+    if not path.is_dir():
+        msg = f"Not a directory: {directory_path}"
+        raise ValueError(msg)
+
+    _validate_llm_flags(clean=clean, summary=summary, images=images)
+
+    from to_markdown.core.batch import convert_batch, discover_files
+
+    files = discover_files(path, recursive=recursive)
+    if not files:
+        msg = f"No supported files found in: {directory_path}"
+        raise ValueError(msg)
+
+    result = convert_batch(
+        files,
+        batch_root=path.resolve(),
+        force=True,
+        clean=clean,
+        summary=summary,
+        images=images,
+        quiet=True,
+    )
+
+    # Build structured response
+    lines = [
+        f"**Directory**: {directory_path}",
+        f"**Recursive**: {recursive}",
+        f"**Total files**: {result.total}",
+        f"**Succeeded**: {len(result.succeeded)}",
+        f"**Failed**: {len(result.failed)}",
+        f"**Skipped**: {len(result.skipped)}",
+    ]
+
+    if result.succeeded:
+        lines.append("\n### Succeeded")
+        for p in result.succeeded:
+            lines.append(f"- {p.name}")
+
+    if result.failed:
+        lines.append("\n### Failed")
+        for p, error in result.failed:
+            lines.append(f"- {p.name}: {error}")
+
+    if result.skipped:
+        lines.append("\n### Skipped")
+        for p, reason in result.skipped:
+            lines.append(f"- {p.name}: {reason}")
+
+    return "\n".join(lines)
+
+
+def handle_list_formats() -> str:
+    """Return supported file formats description."""
+    return SUPPORTED_FORMATS_DESCRIPTION
+
+
+def handle_get_status() -> str:
+    """Return tool version and system status."""
+    llm_available = _check_llm_available()
+    api_key_set = bool(os.environ.get(GEMINI_API_KEY_ENV))
+
+    lines = [
+        f"**Version**: {__version__}",
+        f"**Python**: {sys.version.split()[0]}",
+        f"**LLM SDK installed**: {llm_available}",
+        f"**GEMINI_API_KEY set**: {api_key_set}",
+    ]
+
+    if llm_available and api_key_set:
+        lines.append("**Smart features**: Available (--clean, --summary, --images)")
+    elif llm_available:
+        lines.append(
+            "**Smart features**: SDK installed but GEMINI_API_KEY not set. "
+            f"Set {GEMINI_API_KEY_ENV} environment variable to enable."
+        )
+    else:
+        lines.append("**Smart features**: Not available. Install with: uv sync --extra llm")
+
+    return "\n".join(lines)
+
+
+def _check_llm_available() -> bool:
+    """Check if google-genai SDK is importable."""
+    try:
+        import google.genai  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def _validate_llm_flags(*, clean: bool, summary: bool, images: bool) -> None:
+    """Validate LLM flags are usable."""
+    if not (clean or summary or images):
+        return
+
+    if not _check_llm_available():
+        msg = (
+            "Smart features (clean, summary, images) require the LLM extras. "
+            "Install with: uv sync --extra llm"
+        )
+        raise ValueError(msg)
+
+    if not os.environ.get(GEMINI_API_KEY_ENV):
+        msg = (
+            f"Smart features require {GEMINI_API_KEY_ENV} to be set. "
+            f"Export it or add it to a .env file."
+        )
+        raise ValueError(msg)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,119 @@
+"""Tests for MCP server setup and tool registration (mcp/server.py)."""
+
+
+class TestServerCreation:
+    """Tests for MCP server initialization."""
+
+    def test_server_creates_successfully(self):
+        from to_markdown.mcp.server import mcp
+
+        assert mcp is not None
+        assert mcp.name == "to-markdown"
+
+    def test_run_server_is_callable(self):
+        from to_markdown.mcp.server import run_server
+
+        assert callable(run_server)
+
+
+class TestToolRegistration:
+    """Tests for tool registration on the MCP server."""
+
+    def test_convert_file_tool_registered(self):
+        from to_markdown.mcp.server import mcp
+
+        tool_names = [t.name for t in mcp._tool_manager.list_tools()]
+        assert "convert_file" in tool_names
+
+    def test_convert_batch_tool_registered(self):
+        from to_markdown.mcp.server import mcp
+
+        tool_names = [t.name for t in mcp._tool_manager.list_tools()]
+        assert "convert_batch" in tool_names
+
+    def test_list_formats_tool_registered(self):
+        from to_markdown.mcp.server import mcp
+
+        tool_names = [t.name for t in mcp._tool_manager.list_tools()]
+        assert "list_formats" in tool_names
+
+    def test_get_status_tool_registered(self):
+        from to_markdown.mcp.server import mcp
+
+        tool_names = [t.name for t in mcp._tool_manager.list_tools()]
+        assert "get_status" in tool_names
+
+    def test_exactly_four_tools_registered(self):
+        from to_markdown.mcp.server import mcp
+
+        tools = mcp._tool_manager.list_tools()
+        assert len(tools) == 4
+
+
+class TestToolSchemas:
+    """Tests for tool parameter schemas."""
+
+    def _get_tool(self, name: str):
+        from to_markdown.mcp.server import mcp
+
+        for tool in mcp._tool_manager.list_tools():
+            if tool.name == name:
+                return tool
+        msg = f"Tool {name} not found"
+        raise ValueError(msg)
+
+    def test_convert_file_has_file_path_param(self):
+        tool = self._get_tool("convert_file")
+        schema = tool.parameters
+        assert "file_path" in schema.get("properties", {})
+        assert "file_path" in schema.get("required", [])
+
+    def test_convert_file_optional_params(self):
+        tool = self._get_tool("convert_file")
+        props = tool.parameters.get("properties", {})
+        for param in ["clean", "summary", "images"]:
+            assert param in props
+
+    def test_convert_batch_has_directory_path_param(self):
+        tool = self._get_tool("convert_batch")
+        schema = tool.parameters
+        assert "directory_path" in schema.get("properties", {})
+        assert "directory_path" in schema.get("required", [])
+
+    def test_convert_batch_has_recursive_param(self):
+        tool = self._get_tool("convert_batch")
+        props = tool.parameters.get("properties", {})
+        assert "recursive" in props
+
+
+class TestModuleImport:
+    """Tests for module import behavior."""
+
+    def test_mcp_package_importable(self):
+        import to_markdown.mcp
+
+        assert hasattr(to_markdown.mcp, "run_server")
+
+    def test_server_importable(self):
+        from to_markdown.mcp.server import mcp, run_server
+
+        assert mcp is not None
+        assert callable(run_server)
+
+    def test_tools_importable(self):
+        from to_markdown.mcp.tools import (
+            handle_convert_batch,
+            handle_convert_file,
+            handle_get_status,
+            handle_list_formats,
+        )
+
+        assert all(
+            callable(f)
+            for f in [
+                handle_convert_file,
+                handle_convert_batch,
+                handle_list_formats,
+                handle_get_status,
+            ]
+        )

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -1,0 +1,149 @@
+"""Tests for MCP tool handlers (mcp/tools.py)."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from to_markdown.core.constants import MAX_MCP_OUTPUT_CHARS
+from to_markdown.mcp.tools import (
+    handle_convert_batch,
+    handle_convert_file,
+    handle_get_status,
+    handle_list_formats,
+)
+
+
+class TestHandleConvertFile:
+    """Tests for handle_convert_file."""
+
+    def test_success_returns_structured_response(self, sample_text_file: Path):
+        result = handle_convert_file(str(sample_text_file))
+        assert "**Source**: sample.txt" in result
+        assert "**Format**: txt" in result
+        assert "**Characters**:" in result
+        assert "---" in result
+        assert "Hello" in result
+
+    def test_file_not_found(self, tmp_path: Path):
+        missing = str(tmp_path / "nonexistent.pdf")
+        with pytest.raises(ValueError, match="File not found"):
+            handle_convert_file(missing)
+
+    def test_not_a_file(self, tmp_path: Path):
+        with pytest.raises(ValueError, match="Not a file"):
+            handle_convert_file(str(tmp_path))
+
+    def test_output_truncation(self, sample_text_file: Path):
+        huge_content = "x" * (MAX_MCP_OUTPUT_CHARS + 1_000)
+        with patch(
+            "to_markdown.core.pipeline.convert_to_string",
+            return_value=huge_content,
+        ):
+            result = handle_convert_file(str(sample_text_file))
+            assert "truncated" in result.lower()
+            assert str(MAX_MCP_OUTPUT_CHARS) in result.replace(",", "")
+
+    def test_features_listed_in_response(
+        self, sample_text_file: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        with (
+            patch("to_markdown.mcp.tools._check_llm_available", return_value=True),
+            patch(
+                "to_markdown.core.pipeline.convert_to_string",
+                return_value="---\ncontent\n",
+            ),
+        ):
+            result = handle_convert_file(str(sample_text_file), clean=True, summary=True)
+            assert "**Features**: clean, summary" in result
+
+    def test_llm_without_sdk_raises(self, sample_text_file: Path):
+        with (
+            patch("to_markdown.mcp.tools._check_llm_available", return_value=False),
+            pytest.raises(ValueError, match="LLM extras"),
+        ):
+            handle_convert_file(str(sample_text_file), clean=True)
+
+    def test_llm_without_api_key_raises(
+        self, sample_text_file: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        with (
+            patch("to_markdown.mcp.tools._check_llm_available", return_value=True),
+            pytest.raises(ValueError, match="GEMINI_API_KEY"),
+        ):
+            handle_convert_file(str(sample_text_file), summary=True)
+
+
+class TestHandleConvertBatch:
+    """Tests for handle_convert_batch."""
+
+    def test_success_with_mixed_results(self, batch_dir: Path):
+        result = handle_convert_batch(str(batch_dir))
+        assert "**Directory**:" in result
+        assert "**Total files**:" in result
+        assert "**Succeeded**:" in result
+
+    def test_directory_not_found(self, tmp_path: Path):
+        missing = str(tmp_path / "nonexistent_dir")
+        with pytest.raises(ValueError, match="Directory not found"):
+            handle_convert_batch(missing)
+
+    def test_not_a_directory(self, sample_text_file: Path):
+        with pytest.raises(ValueError, match="Not a directory"):
+            handle_convert_batch(str(sample_text_file))
+
+    def test_empty_directory(self, empty_dir: Path):
+        with pytest.raises(ValueError, match="No supported files"):
+            handle_convert_batch(str(empty_dir))
+
+    def test_non_recursive(self, batch_dir: Path):
+        result = handle_convert_batch(str(batch_dir), recursive=False)
+        assert "**Recursive**: False" in result
+
+
+class TestHandleListFormats:
+    """Tests for handle_list_formats."""
+
+    def test_returns_format_description(self):
+        result = handle_list_formats()
+        assert "PDF" in result
+        assert "DOCX" in result
+        assert "PNG" in result
+        assert "Kreuzberg" in result
+
+    def test_returns_string(self):
+        assert isinstance(handle_list_formats(), str)
+
+
+class TestHandleGetStatus:
+    """Tests for handle_get_status."""
+
+    def test_returns_version(self):
+        from to_markdown import __version__
+
+        result = handle_get_status()
+        assert __version__ in result
+
+    def test_returns_python_version(self):
+        result = handle_get_status()
+        assert "**Python**:" in result
+
+    def test_llm_available_with_key(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        with patch("to_markdown.mcp.tools._check_llm_available", return_value=True):
+            result = handle_get_status()
+            assert "Available" in result
+
+    def test_llm_not_installed(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        with patch("to_markdown.mcp.tools._check_llm_available", return_value=False):
+            result = handle_get_status()
+            assert "Not available" in result
+
+    def test_llm_installed_no_key(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        with patch("to_markdown.mcp.tools._check_llm_available", return_value=True):
+            result = handle_get_status()
+            assert "GEMINI_API_KEY not set" in result

--- a/uv.lock
+++ b/uv.lock
@@ -479,6 +479,15 @@ wheels = [
 ]
 
 [[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.11"
 source = { registry = "https://pypi.org/simple" }
@@ -494,6 +503,33 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
 ]
 
 [[package]]
@@ -562,6 +598,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "mcp"
+version = "1.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/6d/62e76bbb8144d6ed86e202b5edd8a4cb631e7c8130f3f4893c3f90262b10/mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66", size = 608005, upload-time = "2026-01-24T19:40:32.468Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/d9/eaa1f80170d2b7c5ba23f3b59f766f3a0bb41155fbc32a69adfa1adaaef9/mcp-1.26.0-py3-none-any.whl", hash = "sha256:904a21c33c25aa98ddbeb47273033c435e595bbacfdb177f4bd87f6dceebe1ca", size = 233615, upload-time = "2026-01-24T19:40:30.652Z" },
 ]
 
 [[package]]
@@ -805,12 +866,40 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-settings"
+version = "2.13.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/6d/fffca34caecc4a3f97bda81b2098da5e8ab7efc9a66e819074a11955d87e/pydantic_settings-2.13.1.tar.gz", hash = "sha256:b4c11847b15237fb0171e1462bf540e294affb9b86db4d9aa5c01730bdbe4025", size = 223826, upload-time = "2026-02-19T13:45:08.055Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/4b/ccc026168948fec4f7555b9164c724cf4125eac006e176541483d2c959be/pydantic_settings-2.13.1-py3-none-any.whl", hash = "sha256:d56fd801823dbeae7f0975e1f8c8e25c258eb75d278ea7abb5d9cebb01b56237", size = 58929, upload-time = "2026-02-19T13:45:06.034Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5a/b46fa56bf322901eee5b0454a34343cdbdae202cd421775a8ee4e42fd519/pyjwt-2.11.0.tar.gz", hash = "sha256:35f95c1f0fbe5d5ba6e43f00271c275f7a1a4db1dab27bf708073b75318ea623", size = 98019, upload-time = "2026-01-30T19:59:55.694Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/01/c26ce75ba460d5cd503da9e13b21a33804d38c2165dec7b716d06b13010c/pyjwt-2.11.0-py3-none-any.whl", hash = "sha256:94a6bde30eb5c8e04fee991062b534071fd1439ef58d2adc9ccb823e7bcd0469", size = 28224, upload-time = "2026-01-30T19:59:54.539Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]
@@ -866,6 +955,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-multipart"
+version = "0.0.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
+]
+
+[[package]]
 name = "python-pptx"
 version = "1.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -878,6 +976,16 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/52/a9/0c0db8d37b2b8a645666f7fd8accea4c6224e013c42b1d5c17c93590cd06/python_pptx-1.0.2.tar.gz", hash = "sha256:479a8af0eaf0f0d76b6f00b0887732874ad2e3188230315290cd1f9dd9cc7095", size = 10109297, upload-time = "2024-08-07T17:33:37.772Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/4f/00be2196329ebbff56ce564aa94efb0fbc828d00de250b1980de1a34ab49/python_pptx-1.0.2-py3-none-any.whl", hash = "sha256:160838e0b8565a8b1f67947675886e9fea18aa5e795db7ae531606d68e785cba", size = 472788, upload-time = "2024-08-07T17:33:28.192Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
+    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
 ]
 
 [[package]]
@@ -907,6 +1015,19 @@ wheels = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.32.5"
 source = { registry = "https://pypi.org/simple" }
@@ -932,6 +1053,43 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582, upload-time = "2026-02-19T17:23:12.474Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d", size = 310458, upload-time = "2026-02-19T17:23:13.732Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "0.30.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/81/dad16382ebbd3d0e0328776d8fd7ca94220e4fa0798d1dc5e7da48cb3201/rpds_py-0.30.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:68f19c879420aa08f61203801423f6cd5ac5f0ac4ac82a2368a9fcd6a9a075e0", size = 362099, upload-time = "2025-11-30T20:23:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/60/19f7884db5d5603edf3c6bce35408f45ad3e97e10007df0e17dd57af18f8/rpds_py-0.30.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ec7c4490c672c1a0389d319b3a9cfcd098dcdc4783991553c332a15acf7249be", size = 353192, upload-time = "2025-11-30T20:23:29.151Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/c4/76eb0e1e72d1a9c4703c69607cec123c29028bff28ce41588792417098ac/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f251c812357a3fed308d684a5079ddfb9d933860fc6de89f2b7ab00da481e65f", size = 384080, upload-time = "2025-11-30T20:23:30.785Z" },
+    { url = "https://files.pythonhosted.org/packages/72/87/87ea665e92f3298d1b26d78814721dc39ed8d2c74b86e83348d6b48a6f31/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac98b175585ecf4c0348fd7b29c3864bda53b805c773cbf7bfdaffc8070c976f", size = 394841, upload-time = "2025-11-30T20:23:32.209Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ad/7783a89ca0587c15dcbf139b4a8364a872a25f861bdb88ed99f9b0dec985/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3e62880792319dbeb7eb866547f2e35973289e7d5696c6e295476448f5b63c87", size = 516670, upload-time = "2025-11-30T20:23:33.742Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/3c/2882bdac942bd2172f3da574eab16f309ae10a3925644e969536553cb4ee/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e7fc54e0900ab35d041b0601431b0a0eb495f0851a0639b6ef90f7741b39a18", size = 408005, upload-time = "2025-11-30T20:23:35.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/81/9a91c0111ce1758c92516a3e44776920b579d9a7c09b2b06b642d4de3f0f/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47e77dc9822d3ad616c3d5759ea5631a75e5809d5a28707744ef79d7a1bcfcad", size = 382112, upload-time = "2025-11-30T20:23:36.842Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/8e/1da49d4a107027e5fbc64daeab96a0706361a2918da10cb41769244b805d/rpds_py-0.30.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b4dc1a6ff022ff85ecafef7979a2c6eb423430e05f1165d6688234e62ba99a07", size = 399049, upload-time = "2025-11-30T20:23:38.343Z" },
+    { url = "https://files.pythonhosted.org/packages/df/5a/7ee239b1aa48a127570ec03becbb29c9d5a9eb092febbd1699d567cae859/rpds_py-0.30.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4559c972db3a360808309e06a74628b95eaccbf961c335c8fe0d590cf587456f", size = 415661, upload-time = "2025-11-30T20:23:40.263Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ea/caa143cf6b772f823bc7929a45da1fa83569ee49b11d18d0ada7f5ee6fd6/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0ed177ed9bded28f8deb6ab40c183cd1192aa0de40c12f38be4d59cd33cb5c65", size = 565606, upload-time = "2025-11-30T20:23:42.186Z" },
+    { url = "https://files.pythonhosted.org/packages/64/91/ac20ba2d69303f961ad8cf55bf7dbdb4763f627291ba3d0d7d67333cced9/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ad1fa8db769b76ea911cb4e10f049d80bf518c104f15b3edb2371cc65375c46f", size = 591126, upload-time = "2025-11-30T20:23:44.086Z" },
+    { url = "https://files.pythonhosted.org/packages/21/20/7ff5f3c8b00c8a95f75985128c26ba44503fb35b8e0259d812766ea966c7/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:46e83c697b1f1c72b50e5ee5adb4353eef7406fb3f2043d64c33f20ad1c2fc53", size = 553371, upload-time = "2025-11-30T20:23:46.004Z" },
+    { url = "https://files.pythonhosted.org/packages/72/c7/81dadd7b27c8ee391c132a6b192111ca58d866577ce2d9b0ca157552cce0/rpds_py-0.30.0-cp314-cp314-win32.whl", hash = "sha256:ee454b2a007d57363c2dfd5b6ca4a5d7e2c518938f8ed3b706e37e5d470801ed", size = 215298, upload-time = "2025-11-30T20:23:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d2/1aaac33287e8cfb07aab2e6b8ac1deca62f6f65411344f1433c55e6f3eb8/rpds_py-0.30.0-cp314-cp314-win_amd64.whl", hash = "sha256:95f0802447ac2d10bcc69f6dc28fe95fdf17940367b21d34e34c737870758950", size = 228604, upload-time = "2025-11-30T20:23:49.501Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/95/ab005315818cc519ad074cb7784dae60d939163108bd2b394e60dc7b5461/rpds_py-0.30.0-cp314-cp314-win_arm64.whl", hash = "sha256:613aa4771c99f03346e54c3f038e4cc574ac09a3ddfb0e8878487335e96dead6", size = 222391, upload-time = "2025-11-30T20:23:50.96Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/68/154fe0194d83b973cdedcdcc88947a2752411165930182ae41d983dcefa6/rpds_py-0.30.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:7e6ecfcb62edfd632e56983964e6884851786443739dbfe3582947e87274f7cb", size = 364868, upload-time = "2025-11-30T20:23:52.494Z" },
+    { url = "https://files.pythonhosted.org/packages/83/69/8bbc8b07ec854d92a8b75668c24d2abcb1719ebf890f5604c61c9369a16f/rpds_py-0.30.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a1d0bc22a7cdc173fedebb73ef81e07faef93692b8c1ad3733b67e31e1b6e1b8", size = 353747, upload-time = "2025-11-30T20:23:54.036Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/00/ba2e50183dbd9abcce9497fa5149c62b4ff3e22d338a30d690f9af970561/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d08f00679177226c4cb8c5265012eea897c8ca3b93f429e546600c971bcbae7", size = 383795, upload-time = "2025-11-30T20:23:55.556Z" },
+    { url = "https://files.pythonhosted.org/packages/05/6f/86f0272b84926bcb0e4c972262f54223e8ecc556b3224d281e6598fc9268/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5965af57d5848192c13534f90f9dd16464f3c37aaf166cc1da1cae1fd5a34898", size = 393330, upload-time = "2025-11-30T20:23:57.033Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e9/0e02bb2e6dc63d212641da45df2b0bf29699d01715913e0d0f017ee29438/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9a4e86e34e9ab6b667c27f3211ca48f73dba7cd3d90f8d5b11be56e5dbc3fb4e", size = 518194, upload-time = "2025-11-30T20:23:58.637Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ca/be7bca14cf21513bdf9c0606aba17d1f389ea2b6987035eb4f62bd923f25/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e5d3e6b26f2c785d65cc25ef1e5267ccbe1b069c5c21b8cc724efee290554419", size = 408340, upload-time = "2025-11-30T20:24:00.2Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c7/736e00ebf39ed81d75544c0da6ef7b0998f8201b369acf842f9a90dc8fce/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:626a7433c34566535b6e56a1b39a7b17ba961e97ce3b80ec62e6f1312c025551", size = 383765, upload-time = "2025-11-30T20:24:01.759Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/3f/da50dfde9956aaf365c4adc9533b100008ed31aea635f2b8d7b627e25b49/rpds_py-0.30.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:acd7eb3f4471577b9b5a41baf02a978e8bdeb08b4b355273994f8b87032000a8", size = 396834, upload-time = "2025-11-30T20:24:03.687Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/00/34bcc2565b6020eab2623349efbdec810676ad571995911f1abdae62a3a0/rpds_py-0.30.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe5fa731a1fa8a0a56b0977413f8cacac1768dad38d16b3a296712709476fbd5", size = 415470, upload-time = "2025-11-30T20:24:05.232Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/28/882e72b5b3e6f718d5453bd4d0d9cf8df36fddeb4ddbbab17869d5868616/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:74a3243a411126362712ee1524dfc90c650a503502f135d54d1b352bd01f2404", size = 565630, upload-time = "2025-11-30T20:24:06.878Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/97/04a65539c17692de5b85c6e293520fd01317fd878ea1995f0367d4532fb1/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:3e8eeb0544f2eb0d2581774be4c3410356eba189529a6b3e36bbbf9696175856", size = 591148, upload-time = "2025-11-30T20:24:08.445Z" },
+    { url = "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40", size = 556030, upload-time = "2025-11-30T20:24:10.956Z" },
+    { url = "https://files.pythonhosted.org/packages/20/53/7c7e784abfa500a2b6b583b147ee4bb5a2b3747a9166bab52fec4b5b5e7d/rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0", size = 211570, upload-time = "2025-11-30T20:24:12.735Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/02/fa464cdfbe6b26e0600b62c528b72d8608f5cc49f96b8d6e38c95d60c676/rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3", size = 226532, upload-time = "2025-11-30T20:24:14.634Z" },
 ]
 
 [[package]]
@@ -990,6 +1148,31 @@ wheels = [
 ]
 
 [[package]]
+name = "sse-starlette"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/8d/00d280c03ffd39aaee0e86ec81e2d3b9253036a0f93f51d10503adef0e65/sse_starlette-3.2.0.tar.gz", hash = "sha256:8127594edfb51abe44eac9c49e59b0b01f1039d0c7461c6fd91d4e03b70da422", size = 27253, upload-time = "2026-01-17T13:11:05.62Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/7f/832f015020844a8b8f7a9cbc103dd76ba8e3875004c41e08440ea3a2b41a/sse_starlette-3.2.0-py3-none-any.whl", hash = "sha256:5876954bd51920fc2cd51baee47a080eb88a37b5b784e615abb0b283f801cdbf", size = 12763, upload-time = "2026-01-17T13:11:03.775Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "0.52.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
+]
+
+[[package]]
 name = "syrupy"
 version = "5.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1038,12 +1221,16 @@ llm = [
     { name = "python-dotenv" },
     { name = "tenacity" },
 ]
+mcp = [
+    { name = "mcp" },
+]
 
 [package.metadata]
 requires-dist = [
     { name = "fpdf2", marker = "extra == 'dev'", specifier = ">=2.8" },
     { name = "google-genai", marker = "extra == 'llm'", specifier = ">=1.59.0" },
     { name = "kreuzberg", specifier = ">=4.3.8" },
+    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.26,<2" },
     { name = "openpyxl", marker = "extra == 'dev'", specifier = ">=3.1" },
     { name = "pillow", marker = "extra == 'dev'", specifier = ">=11.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0" },
@@ -1058,7 +1245,7 @@ requires-dist = [
     { name = "tenacity", marker = "extra == 'llm'", specifier = ">=8.0" },
     { name = "typer", specifier = ">=0.24.0" },
 ]
-provides-extras = ["llm", "dev"]
+provides-extras = ["llm", "mcp", "dev"]
 
 [[package]]
 name = "typer"
@@ -1103,6 +1290,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/32/ce/eeb58ae4ac36fe09e3842eb02e0eb676bf2c53ae062b98f1b2531673efdd/uvicorn-0.41.0.tar.gz", hash = "sha256:09d11cf7008da33113824ee5a1c6422d89fbc2ff476540d69a34c87fab8b571a", size = 82633, upload-time = "2026-02-16T23:07:24.1Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/e4/d04a086285c20886c0daad0e026f250869201013d18f81d9ff5eada73a88/uvicorn-0.41.0-py3-none-any.whl", hash = "sha256:29e35b1d2c36a04b9e180d4007ede3bcb32a85fbdfd6c6aeb3f26839de088187", size = 68783, upload-time = "2026-02-16T23:07:22.357Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add MCP server (`src/to_markdown/mcp/`) with 4 tools: `convert_file`, `convert_batch`, `list_formats`, `get_status`
- Add `convert_to_string()` to pipeline for file-less conversion (MCP use case)
- Add `.mcp.json` for Claude Code auto-discovery, README docs for Claude Desktop, Codex CLI, Gemini CLI
- Add `[mcp]` optional extra (`mcp>=1.26,<2`), structured response envelopes, output truncation
- 40 new tests (257 total), decisions D-63 through D-70, phase files for 0110-0130

## Test plan

- [x] `uv run pytest` - 257 tests pass
- [x] `uv run ruff check` - lint clean
- [x] `uv run ruff format --check` - format clean
- [x] MCP server starts: `uv run python -m to_markdown.mcp`
- [x] Live test: `convert_file`, `list_formats`, `get_status` called from Claude Code via MCP
- [x] USER GATE confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)